### PR TITLE
feat: use plugin to update library to amplitude-ts-gtm

### DIFF
--- a/src/amplitude-wrapper.js
+++ b/src/amplitude-wrapper.js
@@ -1,3 +1,5 @@
+import { version } from '../package.json';
+
 /* Amplitude JavaScript SDK begin */
 ! function() {
   "use strict";
@@ -18,7 +20,7 @@
                       type: 'enrichment',
                       setup: async () => undefined,
                       execute: async (event) => {
-                          event['library'] = `amplitude-ts-gtm/3.0.0-beta.4`
+                          event['library'] = `amplitude-ts-gtm/${version}`;
                           return event;
                       },
                   };
@@ -26,9 +28,11 @@
 
               let _init = e.amplitude.init; // avoid infinite loop
               // as plugin order cannot be adjusted, init first then add library plugin to overwrite the library value
-              e.amplitude.init = (...args) => _init(...args).promise.then(() =>
-                  e.amplitude.add(gtmLibraryPlugin())
-              );
+              e.amplitude.init = (...args) => {
+                let client = _init(...args);
+                client.promise.then(() => e.amplitude.add(gtmLibraryPlugin()));
+                return client;
+              };
           };
           var s = t.getElementsByTagName("script")[0];
 

--- a/src/amplitude-wrapper.js
+++ b/src/amplitude-wrapper.js
@@ -12,6 +12,23 @@
           var r = t.createElement("script");
           r.type = "text/javascript", r.integrity = "sha384-QhZkEQJe2NFJ4yDkn/RFnD+NP0FINrep4tUh958v8McXRqszeRUQWbwBCfFqZvnF", r.crossOrigin = "anonymous", r.async = !0, r.src = "https://cdn.amplitude.com/libs/marketing-analytics-browser-0.2.0-min.js.gz", r.onload = function() {
               e.amplitude.runQueuedFunctions || console.log("[Amplitude] Error: could not load SDK")
+              var gtmLibraryPlugin = () => {
+                  return {
+                      name: 'gtm-library-enrichment',
+                      type: 'enrichment',
+                      setup: async () => undefined,
+                      execute: async (event) => {
+                          event['library'] = `amplitude-ts-gtm/3.0.0-beta.4`
+                          return event;
+                      },
+                  };
+              };
+
+              let _init = e.amplitude.init; // avoid infinite loop
+              // as plugin order cannot be adjusted, init first then add library plugin to overwrite the library value
+              e.amplitude.init = (...args) => _init(...args).promise.then(() =>
+                  e.amplitude.add(gtmLibraryPlugin())
+              );
           };
           var s = t.getElementsByTagName("script")[0];
 
@@ -66,7 +83,7 @@
 
 /* Amplitude Wrapper begin */
 (function(a,p) {
-  
+
   // If window.amplitude doesn't exist, return
   if (!a.amplitude || typeof a.amplitude.init !== 'function') return;
 
@@ -114,7 +131,7 @@
    */
   var identify = function(args, group) {
       args = args.shift();
-      
+
       // Validate identify args
       if (!Array.isArray(args) || args.length === 0) return;
 
@@ -129,7 +146,7 @@
 
           // If not a valid "identify" command, return
           if (identifyEnum.indexOf(cmd) === -1) return;
-          
+
           identifyInstance[cmd].apply(identifyInstance, identifyParams);
       });
 
@@ -151,7 +168,7 @@
    *     ['prepend', 'someOtherGroupUserProp', 'someValue']
    *   ]
    * );
-   * 
+   *
    */
   var groupIdentify = function(args) {
       // Validate the arguments
@@ -174,7 +191,7 @@
    *   revenueType: 'purchase',
    *   eventProperties: {'someKey': 'someValue}
    * }
-   * 
+   *
    */
   var revenue = function(args) {
       args = args.shift();
@@ -191,12 +208,12 @@
       a.amplitude.revenue(revenue);
   };
 
+
   // Build the command wrapper logic
   a[p] = a[p] || function() {
-
       // Build array out of arguments
       var args = [].slice.call(arguments, 0);
-      
+
       // Pick the first argument as the command
       var cmd = args.shift();
 
@@ -214,7 +231,6 @@
 
       // Otherwise call the method and pass the arguments
       return a.amplitude[cmd].apply(this, args);
-
   };
 })(window, '_amplitude')
 /* Amplitude wrapper end */


### PR DESCRIPTION
## Description
- feat: use plugin to update library to amplitude-ts-gtm

## Test
- local test with index.html with `yarn prepublishOnly` (`import` only works in modules)

```
<!DOCTYPE html>
<html lang="en">
  <head>
    <title>Title of the document</title>
    <script type = "text/javascript" src = "./dist/index.js"></script>
  </head>
  <body>
  
  <h1>This is a heading</h1>
  <p>This is a paragraph.</p>
  
  </body>
</html>
```

```js
amplitude.init("xxx", 'marvin@amplitude.com', {logLevel: 4})
amplitude.track("test")
```
![Screen Shot 2023-01-04 at 11 34 22 AM](https://user-images.githubusercontent.com/8689754/210635186-6350bfcb-3717-4cd3-9cb2-b9263bcd835f.png)

![image](https://user-images.githubusercontent.com/8689754/211378854-b99fb958-5a61-46d7-860d-89f19ab92fb6.png)