### PR TITLE
feat: enable to get revenue from GTM template

### DIFF
--- a/src/amplitude-wrapper.js
+++ b/src/amplitude-wrapper.js
@@ -126,8 +126,8 @@ import { version } from '../package.json';
           .setQuantity(args.quantity || 1)
           .setPrice(args.price)
           .setRevenueType(args.revenueType || '')
-          .setEventProperties(args.eventProperties || {});
-
+          .setEventProperties(args.eventProperties || {})
+          .setRevenue(args.revenue || (args.price * (args.quantity || 1)));
       client.revenue(revenue);
   };
 


### PR DESCRIPTION
It's related to this issue. 
https://discourse.amplitude.com/t/gtm-browser-sdk-template-no-revenue-in-revenue-amount-event/10092/15
When sending a Revenue event, it will have 2 events get shown in the event stream, which are (1) `[Amplitude] Revenue` - the original revenue event and (2)`[Amplitude] Revenue unverified` or `[Amplitude] Revenue verified`. 
If there is no `$revenue` send in (1), it won't have the `$revenue` property. It will be auto-populated during the verification step which is (2).
However, `$revenue` is a valid Revenue field, and it's able to be set in the SDK. 
I think we'd better also enable set revenue in the GTM template. 

Will have another pr to add set revenue in the GTM template as a follow-up pr. 