### PR TITLE
README: fix typos in documentation for setTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,12 @@ window._amplitude(
 ```
 
 ## `setTransport`
-Set the transport type to one of `xhr`, `sendBeacon`, or `fetch`.
+Set the transport type to one of `xhr`, `beacon`, or `fetch`.
 
 Example:
 ```
 window._amplitude(
-  'setTransportType',
-  'sendBeacon'
+  'setTransport',
+  'beacon'
 );
 ```


### PR DESCRIPTION
We're using the Amplitude GTM template and are trying to "Set the transport to use beacon only when exiting the page".

The [code sample from the Browser 2.0 SDK docs](https://www.docs.developers.amplitude.com/data/sdks/browser-2/#set-the-transport-to-use-beacon-only-when-exiting-page) is as follows:

```js
window.addEventListener('pagehide',
  () => {
    amplitude.setTransport('beacon') 
    // Sets https transport to use `sendBeacon` API
    amplitude.flush()
  },
);
```

The [readme for the `amplitude-js-gtm` library](https://www.npmjs.com/package/@amplitude/amplitude-js-gtm#settransport) loaded/used by the GTM template shows the following docs for using `setTransport` via the GTM wrapper: https://www.npmjs.com/package/@amplitude/amplitude-js-gtm#settransport

```js
window._amplitude(
  'setTransportType',
  'sendBeacon'
);
```

Looking at the underlying source repos, it seems there may be two typos here:

1. `setTransportType` is not in [the enum of available events](https://github.com/amplitude/amplitude-js-gtm/blob/v3.x/src/amplitude-wrapper.js#L38) (it appears it should be `setTransport` instead)
2. in the underlying Browser 2.0 SDK, [the `browser-client`'s `setTransport` method](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-browser/src/browser-client.ts#L211-L217) expects an argument of type [TransportType](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-types/src/transport.ts#L8), which uses `beacon` (not `sendBeacon`):
```ts
export type TransportType = 'xhr' | 'beacon' | 'fetch';
```

---

This PR updates the docs to reflect the above, but it's entirely possible I'm just not following the source packages correctly...so please let me know if I'm entirely missing things! 🙈 

Separately (and not implemented in this PR): would it be worth making the early return in the command wrapper throw an error or log when an unrecognized command is provided instead of silently ignoring it? https://github.com/amplitude/amplitude-js-gtm/blob/v3.x/src/amplitude-wrapper.js#L193