### PR TITLE
ci: fix ci issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,12 +84,12 @@ jobs:
           npm publish
 
       - name: Build package
-        if: "${{ env.RELEASE_BRANCH === 'v3.x' }}"
+        if: "${{ env.RELEASE_BRANCH == 'v3.x' }}"
         run: |
           npm run build:prod
 
       - name: Publish to Amplitude CDN
-        if: "${{ env.RELEASE_BRANCH === 'v3.x' }}"
+        if: "${{ env.RELEASE_BRANCH == 'v3.x' }}"
         run: |
           npm run deploy
         env:


### PR DESCRIPTION

`===` is not a valid symble in CI. 

The workflow is not valid. .github/workflows/release.yml (Line: 87, Col: 13): Unexpected symbol: '='. Located at position 22 within expression: env.RELEASE_BRANCH === 'v3.x' .github/workflows/release.yml (Line: 92, Col: 13): Unexpected symbol: '='. Located at position 22 within expression: env.RELEASE_BRANCH === 'v3.x'
