### PR TITLE
ci: grant permisson to upload file to aws

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [authorize]
+    permissions:
+      id-token: write
+      contents: write
     env:
       RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
       RELEASE_BRANCH: ${{ github.event.inputs.releaseBranch }}


### PR DESCRIPTION
https://github.com/marketplace/actions/configure-aws-credentials-v2-action-for-github-actions#usage
These permissions are needed to interact with GitHub's [OIDC Token endpoint](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect).
