### PR TITLE
build: add webpack hashFunction

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,5 +12,6 @@ module.exports = {
   output: {
     filename: "index.js",
     path: path.resolve(__dirname, "dist"),
+    hashFunction: 'xxhash64',
   },
 };


### PR DESCRIPTION
This pr is for fixing the error after upgrading the node version to LTS in Github Action, 
<img width="1162" alt="Screenshot 2024-03-14 at 5 33 20 PM" src="https://github.com/amplitude/amplitude-js-gtm/assets/13028329/2365bd26-42d0-4e9d-a06f-d62424cfad5d">

Reference:
https://stackoverflow.com/a/73465262