### PR TITLE
feat: support excludeReferrers regex

### DIFF
--- a/src/amplitude-wrapper.js
+++ b/src/amplitude-wrapper.js
@@ -154,6 +154,15 @@ var amplitudeUserAgentEnrichmentPlugin=function(i){"use strict";var e=function()
   var init = function(client, args) {
       const argsLength = args.length;
       const configuration = args[argsLength - 1];
+
+      const excludeReferrers = [
+        ...configuration.defaultTracking.attribution.excludeReferrersText || [],
+        ...configuration.defaultTracking.attribution.excludeReferrersRegex?.map(item => new RegExp(item)) || []
+      ];
+      delete configuration.defaultTracking.attribution.excludeReferrersText;
+      delete configuration.defaultTracking.attribution.excludeReferrersRegex;
+      configuration.defaultTracking.attribution.excludeReferrers = excludeReferrers;
+
       const userAgentEnrichmentOptions = configuration['userAgentEnrichmentOptions'];
       const pageViewLegacy = configuration['pageViewLegacy'];
 


### PR DESCRIPTION
Support regex in GTM 
1. Convert each string in `configuration.defaultTracking.attribution` to a RegExp object
2. Merge results of step 1 and `configuration.defaultTracking.attribution.excludeReferrersText` (which are just strings for exact match) to be the actual 
 `configuration.defaultTracking.attribution.excludeReferrers`