### PR TITLE
ci: add v3 release (#53)

### DIFF
--- a/.github/workflows/publish-v3.yml
+++ b/.github/workflows/publish-v3.yml
@@ -1,0 +1,90 @@
+name: Publish v3.x
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version (ie. minor, patch)'
+        required: true
+        type: choice
+        options:
+          - minor
+          - patch
+          - preminor
+          - prepatch
+          - prerelease
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.actor }} permission check to do a release
+        uses: 'lannonbr/repo-permission-check-action@2.0.2'
+        with:
+          permission: 'admin'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: [authorize]
+    permissions:
+      id-token: write
+      contents: write
+    env:
+      RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+
+    steps:
+      - name: Check out git repository
+        uses: actions/checkout@v3
+        with:
+          ref: v3.x
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Install project dependencies
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: Configure Git User
+        run: |
+          git config --global user.name amplitude-sdk-bot
+          git config --global user.email amplitude-sdk-bot@users.noreply.github.com
+
+      - name: Configure NPM User
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}" > ~/.npmrc
+          npm whoami
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::358203115967:role/github-actions-role
+          aws-region: us-west-2
+
+      - name: Create new version
+        run: |
+          CURRENT_VERSION=$(npm info . version)
+          STAGED_VERSION=$(npx semver $CURRENT_VERSION -i ${{ env.RELEASE_VERSION }} --preid beta)
+          npm version $STAGED_VERSION
+          git push
+          git push origin v$STAGED_VERSION
+
+      - name: Pubish package
+        run: |
+          npm publish
+
+      - name: Build package
+        run: |
+          npm run build:prod
+
+      - name: Publish to Amplitude CDN
+        run: |
+          npm run deploy
+        env:
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}


### PR DESCRIPTION
Cherry pick the commit from https://github.com/amplitude/amplitude-js-gtm/pull/53 as Github doesn't show actions from branches other than main.  