### PR TITLE
fix: configuration.defaultTracking is false

### DIFF
--- a/src/amplitude-wrapper.js
+++ b/src/amplitude-wrapper.js
@@ -155,14 +155,16 @@ var amplitudeUserAgentEnrichmentPlugin=function(i){"use strict";var e=function()
       const argsLength = args.length;
       const configuration = args[argsLength - 1];
 
-      const excludeReferrers = [
-        ...configuration.defaultTracking.attribution.excludeReferrersText || [],
-        ...configuration.defaultTracking.attribution.excludeReferrersRegex?.map(item => new RegExp(item)) || []
-      ];
-      delete configuration.defaultTracking.attribution.excludeReferrersText;
-      delete configuration.defaultTracking.attribution.excludeReferrersRegex;
-      configuration.defaultTracking.attribution.excludeReferrers = excludeReferrers;
-
+      if (configuration.defaultTracking.attribution) {
+        const excludeReferrers = [
+          ...(configuration.defaultTracking.attribution.excludeReferrersText || []),
+          ...(configuration.defaultTracking.attribution.excludeReferrersRegex?.map(item => new RegExp(item)) || [])
+        ];
+        delete configuration.defaultTracking.attribution.excludeReferrersText;
+        delete configuration.defaultTracking.attribution.excludeReferrersRegex;
+        configuration.defaultTracking.attribution.excludeReferrers = excludeReferrers;
+      }
+      
       const userAgentEnrichmentOptions = configuration['userAgentEnrichmentOptions'];
       const pageViewLegacy = configuration['pageViewLegacy'];
 


### PR DESCRIPTION
Jira ticket: [AMP-108452]

When `configuration.defaultTracking = false`, `configuration.defaultTracking.attribution.excludeReferrersText` will raise an error `Cannot read properties of undefined (reading 'excludeReferrersText')`.

Fix this by adding a if statement. 

[AMP-108452]: https://amplitude.atlassian.net/browse/AMP-108452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ