### PR TITLE
fix: only pass currency, receipt and signature when populated

### DIFF
--- a/src/amplitude-wrapper.js
+++ b/src/amplitude-wrapper.js
@@ -154,9 +154,13 @@ const LOG_PREFIX = '[Amplitude / GTM]';
           .setProductId(args.productId)
           .setQuantity(args.quantity || 1)
           .setPrice(args.price)
-          .setRevenueType(args.revenueType || '')
-          .setEventProperties(args.eventProperties || {})
           .setRevenue(args.revenue || (args.price * (args.quantity || 1)));
+          if (args.revenueType) {
+            revenue.setRevenueType(args.revenueType)
+          }
+          if (args.eventProperties) {
+            revenue.setEventProperties(args.eventProperties)
+          }
           if (args.currency) {
             revenue.setCurrency(args.currency);
           }

--- a/src/amplitude-wrapper.js
+++ b/src/amplitude-wrapper.js
@@ -156,10 +156,16 @@ const LOG_PREFIX = '[Amplitude / GTM]';
           .setPrice(args.price)
           .setRevenueType(args.revenueType || '')
           .setEventProperties(args.eventProperties || {})
-          .setRevenue(args.revenue || (args.price * (args.quantity || 1)))
-          .setCurrency(args.currency || '')
-          .setReceipt(args.receipt || '')
-          .setReceiptSig(args.receiptSig || '');
+          .setRevenue(args.revenue || (args.price * (args.quantity || 1)));
+          if (args.currency) {
+            revenue.setCurrency(args.currency);
+          }
+          if (args.receipt) {
+            revenue.setReceipt(args.receipt);
+          }
+          if (args.receiptSig) {
+            revenue.setReceiptSig(args.receiptSig);
+          }
       client.revenue(revenue);
   };
 


### PR DESCRIPTION
We pass empty values unnecessarily. Only set values when these values are available