### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash - quotation fix

### DIFF
--- a/.github/workflows/publish-v3.yml
+++ b/.github/workflows/publish-v3.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: 'lannonbr/repo-permission-check-action@2.0.2'
+        uses: 'lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f' # 2.0.2
         with:
           permission: 'admin'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: 'lannonbr/repo-permission-check-action@2.0.2'
+        uses: 'lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f' # 2.0.2
         with:
           permission: 'admin'
         env:


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via [automated scripts](https://github.com/amplitude/tools/tree/master/seceng/github_actions/pin-gha).
This PR fixes an error with the previous script not correctly parsing lines in "" quotations.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 4/10/2026.

For any questions, please ask in the Slack channel #help-security.
